### PR TITLE
Add Boost.JSON:

### DIFF
--- a/libs/json/boost-json/project.json
+++ b/libs/json/boost-json/project.json
@@ -1,0 +1,30 @@
+{
+  "type": "github",
+  "url": "https://github.com/CPPAlliance/json",
+  "working_dir": "include",
+  "files": [
+    "boost/json.hpp",
+    "boost/pilfer.hpp",
+    "boost/json/array.hpp",
+    "boost/json/basic_parser.hpp",
+    "boost/json/config.hpp",
+    "boost/json/error.hpp",
+    "boost/json/kind.hpp",
+    "boost/json/monotonic_resource.hpp",
+    "boost/json/number_cast.hpp",
+    "boost/json/object.hpp",
+    "boost/json/parser.hpp",
+    "boost/json/serializer.hpp",
+    "boost/json/src.hpp",
+    "boost/json/storage_ptr.hpp",
+    "boost/json/string.hpp",
+    "boost/json/to_value.hpp",
+    "boost/json/traits.hpp",
+    "boost/json/value_cast.hpp",
+    "boost/json/value.hpp",
+    "boost/json/value_ref.hpp"
+  ],
+  "versions": [
+    "develop"
+  ]
+}


### PR DESCRIPTION
This configuration relies on boost-devel being available on the host system. I don't know how to configure this to download and build boost prior. Happy to take instruction if it's necessary.

Sincerely,

Richard Hodges
Staff Engineer
C++ Alliance
